### PR TITLE
Restore basic page functionality to ZeroHedege.

### DIFF
--- a/easylist/easylist_specific_block.txt
+++ b/easylist/easylist_specific_block.txt
@@ -3125,7 +3125,6 @@
 ||zdnet.com/mds/
 ||zdnet.com/medusa/
 ||zerochan.net/skyscraper.html
-||zerohedge.com/s3fs-js/js/$script
 ||zeropaid.com/images/
 ||zeropaid.com^*/94.jpg
 ||ziddu.com/images/140x150_egglad.gif


### PR DESCRIPTION
Not sure of the goal of this specific exclusion but all sitewide JS is stored in this directory and it broke comments, menus, etc.

We are the technical team charged with keeping the site running and we had a few complaints this morning about these changes. Thanks, -mf