### PR TITLE
Fix Anonymous Read Count on Zerohedge

### DIFF
--- a/easyprivacy/easyprivacy_specific.txt
+++ b/easyprivacy/easyprivacy_specific.txt
@@ -481,7 +481,6 @@
 ||counter.entertainmentwise.com^
 ||counter.sina.com.cn^
 ||counter.theconversation.edu.au^
-||counter.zerohedge.com^
 ||coupons.com/pmm.asp
 ||courierpress.com/metrics/
 ||coursehero.com/v1/data-tracking
@@ -2536,7 +2535,6 @@
 ||zawya.com^*/logFile.cfm?
 ||zdnet.com/wi?
 ||zedo.com/img/bh.gif?
-||zerohedge.com/statistics-ajax?
 ||zeus.slader.com^
 ||zion.api.cnn.io^
 ||zmags.com/CommunityAnalyticsTracking


### PR DESCRIPTION
Hired development firm here from ZeroHedge. The publisher asked us to look into why the anonymous article read counts (tracking popularity only) stopped working on the page and we traced it to this list and GET request. To be clear this get request only retrieves the number of reads for a list of articles by node id. Example:

[Link to GET request that is triggered on front page.](https://www.zerohedge.com/statistics-ajax?entity_ids=668731,669090,669129,669144,669145,669146,669147,669149,669150,669152,669154,669155,669157,669161,669163,669164,669170,669172,669173,669176)

As you can see no private information is exchanged at all. Is this still in violation of your privacy position? A number of readers were complaining about the site being broken as a result of read counts missing and I thought it was worth following up. Thanks, -mf